### PR TITLE
change ui. namespace to ao.

### DIFF
--- a/jquery.customevents.plugin-boilerplate.js
+++ b/jquery.customevents.plugin-boilerplate.js
@@ -14,7 +14,7 @@ and allows them to function independently.
 */
 
 (function(){
-    $.widget("ui.eventStatus", {
+    $.widget("ao.eventStatus", {
         options: {
 
         },

--- a/jquery.widget-factory.requirejs.boilerplate.js
+++ b/jquery.widget-factory.requirejs.boilerplate.js
@@ -11,7 +11,7 @@ This assumes you are using the RequireJS+jQuery file, and that the following
 files are all in the same directory: 
 
 - require-jquery.js 
-- jquery-ao.custom.min.js (custom jQueryUI build with widget factory) 
+- jquery-ui.custom.min.js (custom jQueryUI build with widget factory) 
 - templates/ 
     - asset.html 
 - ao.myWidget.js 

--- a/jquery.widget-factory.requirejs.boilerplate.js
+++ b/jquery.widget-factory.requirejs.boilerplate.js
@@ -11,18 +11,18 @@ This assumes you are using the RequireJS+jQuery file, and that the following
 files are all in the same directory: 
 
 - require-jquery.js 
-- jquery-ui.custom.min.js (custom jQueryUI build with widget factory) 
+- jquery-ao.custom.min.js (custom jQueryUI build with widget factory) 
 - templates/ 
     - asset.html 
-- ui.myWidget.js 
+- ao.myWidget.js 
 
 Then you can construct the widget like so: 
 */
 
 
-//ui.myWidget.js file: 
-define("ui.myWidget", ["jquery", "text!templates/asset.html", "jquery-ui.custom.min"], function ($, assetHtml) { 
-    $.widget("ui.myWidget", { 
+//ao.myWidget.js file: 
+define("ao.myWidget", ["jquery", "text!templates/asset.html", "jquery-ao.custom.min"], function ($, assetHtml) { 
+    $.widget("ao.myWidget", { 
         options: {}, 
         //Setup widget (eg. element creation, apply theming, bind events etc.)
         _create: function () {
@@ -75,8 +75,8 @@ define("ui.myWidget", ["jquery", "text!templates/asset.html", "jquery-ui.custom.
 
 /*
 If you are going to use the RequireJS optimizer to combine files  together, you can 
-leave off the "ui.myWidget" argument to define: 
-define(["jquery", "text!templates/asset.html", "jquery-ui.custom.min"], ..... 
+leave off the "ao.myWidget" argument to define: 
+define(["jquery", "text!templates/asset.html", "jquery-ao.custom.min"], ..... 
 */
 
 

--- a/jquery.widget-factory.requirejs.boilerplate.js
+++ b/jquery.widget-factory.requirejs.boilerplate.js
@@ -14,15 +14,15 @@ files are all in the same directory:
 - jquery-ui.custom.min.js (custom jQueryUI build with widget factory) 
 - templates/ 
     - asset.html 
-- ui.myWidget.js 
+- ao.myWidget.js 
 
 Then you can construct the widget like so: 
 */
 
 
-//ui.myWidget.js file: 
-define("ui.myWidget", ["jquery", "text!templates/asset.html", "jquery-ui.custom.min"], function ($, assetHtml) { 
-    $.widget("ui.myWidget", { 
+//ao.myWidget.js file: 
+define("ao.myWidget", ["jquery", "text!templates/asset.html", "jquery-ui.custom.min"], function ($, assetHtml) { 
+    $.widget("ao.myWidget", { 
         options: {}, 
         //Setup widget (eg. element creation, apply theming, bind events etc.)
         _create: function () {
@@ -75,7 +75,7 @@ define("ui.myWidget", ["jquery", "text!templates/asset.html", "jquery-ui.custom.
 
 /*
 If you are going to use the RequireJS optimizer to combine files  together, you can 
-leave off the "ui.myWidget" argument to define: 
+leave off the "ao.myWidget" argument to define: 
 define(["jquery", "text!templates/asset.html", "jquery-ui.custom.min"], ..... 
 */
 


### PR DESCRIPTION
It's recommended that the ui. namespace is only used for official jquery widgets:

"All jQuery UI widgets exist in the $.ui namespace, which is reserved for official widgets, so make sure you change this to something unique. Namespaces are used internally for organizational purposes; they do not allow you to create multiple widgets with the same name." - http://www.erichynds.com/jquery/tips-for-developing-jquery-ui-widgets/

"The ui namespace is reserved for official jQuery UI plugins
Just because you're using the widget factory doesn't mean you have to use ui
We'd kinda prefer if you didn't :)" - http://ajpiano.com/widgetfactory/#slide22
