### PR TITLE
Prototype object alias

### DIFF
--- a/jquery.basic.plugin-boilerplate.js
+++ b/jquery.basic.plugin-boilerplate.js
@@ -60,4 +60,4 @@
         });
     }
 
-})(jQuery, window);
+})(jQuery, window, document);

--- a/jquery.basic.plugin-boilerplate.js
+++ b/jquery.basic.plugin-boilerplate.js
@@ -23,25 +23,28 @@
     var pluginName = 'defaultPluginName',
         defaults = {
             propertyName: "value"
-        };
-
-    // The actual plugin constructor
-    function Plugin( element, options ) {
-        this.element = element;
-
-        // jQuery has an extend method which merges the contents of two or 
-        // more objects, storing the result in the first object. The first object
-        // is generally empty as we don't want to alter the default options for
-        // future instances of the plugin
-        this.options = $.extend( {}, defaults, options) ;
+        },
         
-        this._defaults = defaults;
-        this._name = pluginName;
+        // The actual plugin constructor
+        Plugin = function( element, options ) {
+            this.element = element;
+    
+            // jQuery has an extend method which merges the contents of two or 
+            // more objects, storing the result in the first object. The first object
+            // is generally empty as we don't want to alter the default options for
+            // future instances of the plugin
+            this.options = $.extend( {}, defaults, options) ;
+            
+            this._defaults = defaults;
+            this._name = pluginName;
+            
+            this.init();
+        },
         
-        this.init();
-    }
+        // alias to Plugin prototype object
+        addMethod = Plugin.prototype;
 
-    Plugin.prototype.init = function () {
+    addMethod.init = function () {
         // Place initialization logic here
         // You already have access to the DOM element and the options via the instance, 
         // e.g., this.element and this.options


### PR DESCRIPTION
Haven't got around to any proper work on this, but suggesting a slight change to the declaration of the Plugin constructor here. You may / may not agree, and I admit it might not be that great of an idea, however have found this structural change quite useful myself.

Modifying structure slightly so that the Plugin constructor function is declared as a variable and adding an alias to the Plugin prototype object. This might ruffle some feathers, but adds a little more contextual meaning to extending the Plugin constructor.
